### PR TITLE
Removed ButtonBase import

### DIFF
--- a/src/components/TestButtonBase/TestButtonBase.tsx
+++ b/src/components/TestButtonBase/TestButtonBase.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { ButtonBase, withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/core';
+
+// Dummy replacement to avoid importing this component from @material-ui/core
+const ButtonBase: React.FC<any> = props => <button {...props}>{props.children}</button>
 
 const StyledButton = withStyles({
   root: {


### PR DESCRIPTION
## Description
This PR exhibits that importing `ButtonBase` from `@material-ui/core` in our plugin messes with the Flex styles. You can see that the accept and reject task buttons lose the styles when the import is there, but the styles are fixed if we remove that import in our plugin.
It can also be seen, that removing the conflicting style from the plugin fixes the issue shown in https://github.com/techmatters/repro-flex2-ui-bug/pull/1, which indicates that this does not only affects the Flex default components, but also the ones based on components exported by `@twilio/flex-ui`.

Before this PR (i.e. as in the `main` branch):
![Screenshot from 2022-08-17 19-52-06](https://user-images.githubusercontent.com/15805319/185259108-0a697f37-0ec7-4e77-b392-4ad4498cddb3.png)

With the changes of this PR:
![Screenshot from 2022-08-17 20-04-40](https://user-images.githubusercontent.com/15805319/185260644-f33ded2b-5d79-4c97-b8de-6ff47cf6b197.png)
The applied style takes effect, and the style of `Button` component imported from `@twilio/flex-ui` is also the expected one. 