### PR TITLE
Wrap the test material button in a StylesProvider that sets it to inject its styles at the top of the document

### DIFF
--- a/src/components/TestButtonBase/TestButtonBase.tsx
+++ b/src/components/TestButtonBase/TestButtonBase.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { ButtonBase, withStyles } from '@material-ui/core';
+import { StylesProvider } from '@material-ui/core/styles';
 
 const StyledButton = withStyles({
   root: {
+    backgroundColor: 'red',
     width: 200,
     height: 40,
   },
 })(ButtonBase);
 
-const TestButtonBase = () => <StyledButton onClick={() => console.log('Clicked!')}>Some button</StyledButton>
+const TestButtonBase = () => <StylesProvider injectFirst={true}><StyledButton onClick={() => console.log('Clicked!')}>Some button</StyledButton></StylesProvider>
 
 export default TestButtonBase;


### PR DESCRIPTION
With this change, we see that the flex styles are applied as expected!

But the material styles are not. :sad-trombone:

I think this shows all of the code in various styling frameworks is working as expected, but the various styles they are creating are just jostling for precedence in the HTML document and overwriting each other